### PR TITLE
Changes in drift code to simulate group effects

### DIFF
--- a/src/ChargeCloudModels/ChargeCloudModels.jl
+++ b/src/ChargeCloudModels/ChargeCloudModels.jl
@@ -8,3 +8,90 @@ end
 struct NBodyChargeCloud{T <: SSDFloat, S} <: AbstractChargeCloud 
     # To be done...
 end
+
+struct Tetrahedron{T}
+    points::Vector{CartesianPoint{T}}
+end
+
+function Tetrahedron(center::CartesianPoint{T}, length::T = T(1)) where {T}
+    points = CartesianPoint{T}[center + CartesianVector{T}(0,0,length)]
+    for φ in (0,120,240)
+        push!(points, center + length * CartesianVector{T}(sqrt(8)/3*cosd(φ), sqrt(8)/3*sind(φ), -1/3))
+    end
+    Tetrahedron{T}( points )
+end
+
+struct Hexahedron{T}
+    points::Vector{CartesianPoint{T}}
+end
+
+function Hexahedron(center::CartesianPoint{T}, length::T = T(1)) where {T}
+    points = CartesianPoint{T}[]
+    for x in (-1,1)
+        for y in (-1,1)
+            for z in (-1,1)
+                push!(points, center + length * sqrt(T(1/3)) * CartesianVector{T}(x,y,z))
+            end
+        end
+    end
+    Hexahedron{T}( points )
+end
+
+struct Octahedron{T}
+    points::Vector{CartesianPoint{T}}
+end
+
+function Octahedron(center::CartesianPoint{T}, length::T = T(1)) where {T}
+    points = CartesianPoint{T}[
+        center + length * CartesianVector{T}(1,0,0),
+        center + length * CartesianVector{T}(-1,0,0),
+        center + length * CartesianVector{T}(0,1,0),
+        center + length * CartesianVector{T}(0,-1,0),
+        center + length * CartesianVector{T}(0,0,1),
+        center + length * CartesianVector{T}(0,0,-1)
+    ]
+    Octahedron{T}( points )
+end
+
+struct Dodecahedron{T}
+    points::Vector{CartesianPoint{T}}
+end
+
+function Dodecahedron(center::CartesianPoint{T}, length::T = T(1)) where {T}
+    points = CartesianPoint{T}[
+        center + sqrt(1/3) * length * CartesianVector{T}(-1,-1,-1),
+        center + sqrt(1/3) * length * CartesianVector{T}(-1,-1,1),
+        center + sqrt(1/3) * length * CartesianVector{T}(-1,1,-1),
+        center + sqrt(1/3) * length * CartesianVector{T}(1,-1,-1),
+        center + sqrt(1/3) * length * CartesianVector{T}(-1,1,1),
+        center + sqrt(1/3) * length * CartesianVector{T}(1,-1,1),
+        center + sqrt(1/3) * length * CartesianVector{T}(1,1,-1),
+        center + sqrt(1/3) * length * CartesianVector{T}(1,1,1),
+    ]
+    for g in (-Base.MathConstants.golden, Base.MathConstants.golden)
+        for invg in (-inv(Base.MathConstants.golden), inv(Base.MathConstants.golden))
+            push!(points, center + sqrt(1/3) * length * CartesianVector{T}(invg, g, 0))
+            push!(points, center + sqrt(1/3) * length * CartesianVector{T}(0, invg, g))
+            push!(points, center + sqrt(1/3) * length * CartesianVector{T}(g, 0, invg))
+        end
+    end
+    Dodecahedron{T}( points )
+end
+
+struct Icosahedron{T}
+    points::Vector{CartesianPoint{T}}
+end
+
+function Icosahedron(center::CartesianPoint{T}, length::T = T(1)) where {T}
+    points = CartesianPoint{T}[]
+    for i in (-1,1)
+        for g in (-Base.MathConstants.golden, Base.MathConstants.golden)
+            push!(points, center + length * CartesianVector{T}(i,0,g) / sqrt(T(2 + Base.MathConstants.golden)))
+            push!(points, center + length * CartesianVector{T}(g,i,0) / sqrt(T(2 + Base.MathConstants.golden)))
+            push!(points, center + length * CartesianVector{T}(0,g,i) / sqrt(T(2 + Base.MathConstants.golden)))
+        end
+    end
+    Icosahedron{T}( points )
+end
+
+include("plot_recipes.jl")

--- a/src/ChargeCloudModels/ChargeCloudModels.jl
+++ b/src/ChargeCloudModels/ChargeCloudModels.jl
@@ -2,7 +2,7 @@ abstract type AbstractChargeCloud end
 
 struct NBodyChargeCloud{T} <: AbstractChargeCloud
     points::Vector{CartesianPoint{T}}
-    charges::Vector{T}
+    energies::Vector{T}
     shell_structure::Vector{Type{<:AbstractChargeCloud}}
 end
 
@@ -103,23 +103,23 @@ include("plot_recipes.jl")
 include("ParticleTypes.jl")
 
 
-function create_charge_cloud(center::CartesianPoint{T}, charge::T, particle_type::Type{PT} = Gamma;
-        radius::T = radius_guess(charge, particle_type), number_of_shells::Int = 2, shell_structure = Dodecahedron
+function create_charge_cloud(center::CartesianPoint{T}, energy::T, particle_type::Type{PT} = Gamma;
+        radius::T = radius_guess(energy, particle_type), number_of_shells::Int = 2, shell_structure = Dodecahedron
     )::NBodyChargeCloud{T} where {T, PT <: ParticleType}
     
     points::Vector{CartesianPoint{T}} = CartesianPoint{T}[center]
-    charges::Vector{T} = T[charge]
+    energies::Vector{T} = T[1]
     shell_structures::Vector{Type} = [PointCharge{T}]
     
     n_shell = 1
     while n_shell <= number_of_shells
         shell = shell_structure(center, n_shell * radius).points
         points = vcat(points, shell)
-        charges = vcat(charges, [exp(-n_shell^2 / 2) for i in 1:length(shell)])
+        energies = vcat(energies, [exp(-n_shell^2 / 2) for i in 1:length(shell)])
         push!(shell_structures, shell_structure{T})
         n_shell += 1
     end
-    return NBodyChargeCloud{T}( points, charges./sum(charges) * charge, shell_structures )
+    return NBodyChargeCloud{T}( points, energies./sum(energies) * energy, shell_structures )
 end
 
 

--- a/src/ChargeCloudModels/ParticleTypes.jl
+++ b/src/ChargeCloudModels/ParticleTypes.jl
@@ -1,0 +1,8 @@
+abstract type ParticleType end
+abstract type Alpha <: ParticleType end
+abstract type Beta <: ParticleType end
+abstract type Gamma <: ParticleType end
+
+radius_guess(charge::T, ::Type{Alpha}) where {T} = T(0.0001)
+radius_guess(charge::T, ::Type{Beta}) where {T} = T(0.0005)
+radius_guess(charge::T, ::Type{Gamma}) where {T} = T(0.0005) 

--- a/src/ChargeCloudModels/plot_recipes.jl
+++ b/src/ChargeCloudModels/plot_recipes.jl
@@ -275,10 +275,9 @@ get_vertices(::Type{Dodecahedron{T}}) where {T} = 20
 get_vertices(::Type{Icosahedron{T}}) where {T} = 12
 
 
-@recipe function f(nbc::NBodyChargeCloud{T}, connect = true) where {T}
+@recipe function f(nbc::NBodyChargeCloud{T}, connect = true, markersize = 10) where {T}
     
     seriescolor --> :blue
-    markersize --> 10
     
     @series begin
         seriescolor --> seriescolor

--- a/src/ChargeCloudModels/plot_recipes.jl
+++ b/src/ChargeCloudModels/plot_recipes.jl
@@ -1,3 +1,17 @@
+@recipe function f(t::PointCharge{T}) where {T}
+
+    seriescolor --> :blue
+    
+    @series begin
+        seriescolor --> seriescolor
+        seriestype --> :scatter
+        markersize --> 6
+        label --> "PointCharge"
+        t.points
+    end
+end
+
+
 @recipe function f(t::Tetrahedron{T}; connect = true) where {T}
     
     linestyle --> :dot
@@ -252,3 +266,39 @@ end
     end
 end
 
+
+get_vertices(::Type{PointCharge{T}}) where {T} = 1
+get_vertices(::Type{Tetrahedron{T}}) where {T} = 4
+get_vertices(::Type{Hexahedron{T}}) where {T} = 8
+get_vertices(::Type{Octahedron{T}}) where {T} = 6
+get_vertices(::Type{Dodecahedron{T}}) where {T} = 20
+get_vertices(::Type{Icosahedron{T}}) where {T} = 12
+
+
+@recipe function f(nbc::NBodyChargeCloud{T}, connect = true) where {T}
+    
+    seriescolor --> :blue
+    markersize --> 10
+    
+    @series begin
+        seriescolor --> seriescolor
+        seriestype --> :scatter
+        markersize --> markersize
+        markerstrokewidth --> 0
+        label --> "NBodyChargeCloud"
+        []
+    end
+    
+    points = nbc.points
+    vertex_no = 0
+    for (shell, shell_structure) in enumerate(nbc.shell_structure)
+        vertices = get_vertices(shell_structure)
+        @series begin
+            markersize --> markersize * exp(-(shell - 1))
+            label --> ""
+            seriescolor --> seriescolor
+            shell_structure(points[vertex_no+1:vertex_no+vertices])
+        end
+        vertex_no += vertices
+    end
+end

--- a/src/ChargeCloudModels/plot_recipes.jl
+++ b/src/ChargeCloudModels/plot_recipes.jl
@@ -1,0 +1,254 @@
+@recipe function f(t::Tetrahedron{T}; connect = true) where {T}
+    
+    linestyle --> :dot
+    seriescolor --> :blue
+    
+    @series begin
+        seriescolor --> seriescolor
+        seriestype --> :scatter
+        markersize --> 6
+        label --> "Tetrahedron"
+        t.points
+    end
+    
+   
+    if connect
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            t.points[vcat(1,2,3,4,2)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            t.points[vcat(3,1,4)]
+        end
+    end
+end
+
+
+@recipe function f(i::Hexahedron{T}; connect = true) where {T}
+    
+    linestyle --> :dot
+    seriescolor --> :blue
+    
+    @series begin
+        seriescolor --> seriescolor
+        seriestype --> :scatter
+        markersize --> 6
+        label --> "Hexahedron"
+        i.points
+    end
+    
+   
+    if connect
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(1,2,6,5,1,3,4,2)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(4,8,7,3)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(5,7)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(6,8)]
+        end
+    end
+end
+
+
+@recipe function f(i::Octahedron{T}) where {T}
+    
+    linestyle --> :dot
+    seriescolor --> :blue
+    
+    @series begin
+        seriescolor --> seriescolor
+        seriestype --> :scatter
+        markersize --> 6
+        label --> "Octahedron"
+        i.points
+    end
+    
+    @series begin
+        seriescolor --> seriescolor
+        seriestype --> :line3d
+        label --> ""
+        linewidth --> 1
+        i.points[vcat(1,3,2,4,1,5,2,6,3,5,4,6,1)]
+    end
+end
+
+
+@recipe function f(i::Dodecahedron{T}; connect = true) where {T}
+    
+    linestyle --> :dot
+    seriescolor --> :blue
+    
+    @series begin
+        seriescolor --> seriescolor
+        seriestype --> :scatter
+        markersize --> 6
+        label --> "Dodecahedron"
+        i.points
+    end
+    
+   
+    if connect
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(1,9,2,14,5,15,3,11,1,10,4,12,6,16,2)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(5,19,16)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(19,8,18,15)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(3,13,10)]
+        end
+        
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(4,17,7,13)]
+        end
+        
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(7,18)]
+        end
+        
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(8,20,17)]
+        end
+        
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(6,20)]
+        end
+        
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(9,12)]
+        end
+        
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(11,14)]
+        end
+    end
+end
+
+
+@recipe function f(i::Icosahedron{T}; connect = true) where {T}
+    
+    linestyle --> :dot
+    seriescolor --> :blue
+    
+    @series begin
+        seriescolor --> seriescolor
+        seriestype --> :scatter
+        markersize --> 6
+        label --> "Icosahedron"
+        i.points
+    end
+    
+   
+    if connect
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(7,6,1,2,3,5,7,3,1,7,11,5,9,2,8,1)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(3,9,10,4,2,9,4,8,6,11,10,12,4)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(5,10,12,8)]
+        end
+
+        @series begin
+            seriescolor --> seriescolor
+            seriestype --> :line3d
+            label --> ""
+            linewidth --> 1
+            i.points[vcat(6,12,11)]
+        end
+    end
+end
+

--- a/src/ChargeDrift/ChargeDrift.jl
+++ b/src/ChargeDrift/ChargeDrift.jl
@@ -95,7 +95,7 @@ end
 end
 
 
-is_zero_vector(v::CartesianVector{T}) where {T <: SSDFloat} = (v == CartesianVector{T}(0,0,0))
+is_approx_zero_vector(v::CartesianVector{T}) where {T <: SSDFloat} = all(abs.(v) .<= geom_atol_zero(T))
 
 function _set_to_zero_vector!(v::Vector{CartesianVector{T}})::Nothing where {T <: SSDFloat}
     for n in eachindex(v)
@@ -109,10 +109,8 @@ function _add_fieldvector_drift!(step_vectors::Vector{CartesianVector{T}}, curre
     for n in eachindex(step_vectors)
         if !done[n]
             step_vectors[n] += get_velocity_vector(velocity_field, _convert_vector(current_pos[n], Val(S)))
-            if is_zero_vector(geom_round.(step_vectors[n]))
+            if is_approx_zero_vector(step_vectors[n])
                 done[n] = true
-                #current_pos[n] += step_vectors[n]
-                #drift_path[n,istep] = current_pos[n]
             end
         end
     end
@@ -235,7 +233,7 @@ function _check_and_update_position!(step_vectors::Vector{CartesianVector{T}},
                 drift_path[n,istep] = next_pos
                 step_vectors *= (1 - i * T(0.001))  # scale down the step_vectors for all other charge clouds
                 Δt *= (1 - i * T(0.001))            # scale down Δt for all charge clouds
-                done[n] = is_zero_vector(geom_round.(next_pos - current_pos[n]))
+                done[n] = is_approx_zero_vector(next_pos - current_pos[n])
                 current_pos[n] = next_pos
             else # if cd_point_type == CD_BULK or CD_OUTSIDE
                 if verbose @warn ("Internal error for charge starting at $(startpos[n])") end

--- a/src/ChargeDrift/ChargeDrift.jl
+++ b/src/ChargeDrift/ChargeDrift.jl
@@ -38,7 +38,8 @@ function _drift_charges(detector::SolidStateDetector{T}, grid::Grid{T, 3}, point
                         starting_points::Vector{CartesianPoint{T}}, energies::Vector{T},
                         electric_field::Interpolations.Extrapolation{<:SVector{3}, 3},
                         cdm::AbstractChargeDriftModel{T},
-                        Δt::RQ; max_nsteps::Int = 2000, verbose::Bool = true)::Vector{EHDriftPath{T}} where {T <: SSDFloat, RQ <: RealQuantity}
+                        Δt::RQ, diffusion::Bool = false, self_repulsion::Bool = false; 
+                        max_nsteps::Int = 2000, verbose::Bool = true)::Vector{EHDriftPath{T}} where {T <: SSDFloat, RQ <: RealQuantity}
 
     drift_paths::Vector{EHDriftPath{T}} = Vector{EHDriftPath{T}}(undef, length(starting_points))
     n_events::Int = length(starting_points)
@@ -48,8 +49,8 @@ function _drift_charges(detector::SolidStateDetector{T}, grid::Grid{T, 3}, point
     drift_path_h::Array{CartesianPoint{T},2} = Array{CartesianPoint{T},2}(undef, n_events, max_nsteps)
     timestamps_e::Vector{T} = Vector{T}(undef, max_nsteps)
     timestamps_h::Vector{T} = Vector{T}(undef, max_nsteps)
-    n_e::Int = _drift_charge!(drift_path_e, timestamps_e, detector, point_types, grid, starting_points, energies./T(ustrip(detector.semiconductors[1].material.E_ionisation)), dt, electric_field, cdm, Electron, verbose = verbose)
-    n_h::Int = _drift_charge!(drift_path_h, timestamps_h, detector, point_types, grid, starting_points, energies./T(ustrip(detector.semiconductors[1].material.E_ionisation)), dt, electric_field, cdm, Hole, verbose = verbose)
+    n_e::Int = _drift_charge!(drift_path_e, timestamps_e, detector, point_types, grid, starting_points, energies./T(ustrip(detector.semiconductors[1].material.E_ionisation)), dt, electric_field, cdm, Electron, diffusion, self_repulsion, verbose = verbose)
+    n_h::Int = _drift_charge!(drift_path_h, timestamps_h, detector, point_types, grid, starting_points, energies./T(ustrip(detector.semiconductors[1].material.E_ionisation)), dt, electric_field, cdm, Hole, diffusion, self_repulsion, verbose = verbose)
     
     for i in eachindex(starting_points)
         drift_paths[i] = EHDriftPath{T, T}( drift_path_e[i,1:n_e], drift_path_h[i,1:n_h], timestamps_e[1:n_e], timestamps_h[1:n_h] )
@@ -63,8 +64,9 @@ function _drift_charge( detector::SolidStateDetector{T}, grid::Grid{T, 3}, point
                        velocity_field_e::Interpolations.Extrapolation{SVector{3, T}, 3},
                        velocity_field_h::Interpolations.Extrapolation{SVector{3, T}, 3},
                        cdm::AbstractChargeDriftModel{T},
-                       Δt::RealQuantity, max_nsteps::Int = 2000, verbose::Bool = true)::Vector{EHDriftPath{T}} where {T <: SSDFloat}
-    return _drift_charges(detector, grid, CartesianPoint{T}.(point_types), [starting_point], velocity_field_e, velocity_field_h, cdm, T(Δt.val) * unit(Δt), max_nsteps = max_nsteps, verbose = verbose)
+                       Δt::RealQuantity, diffusion::Bool = false, self_repulsion::Bool = false;
+                       max_nsteps::Int = 2000, verbose::Bool = true)::Vector{EHDriftPath{T}} where {T <: SSDFloat}
+    return _drift_charges(detector, grid, CartesianPoint{T}.(point_types), [starting_point], velocity_field_e, velocity_field_h, cdm, T(Δt.val) * unit(Δt), diffusion, self_repulsion, max_nsteps = max_nsteps, verbose = verbose)
 end
 
 @inline _convert_vector(pt::CartesianPoint, ::Val{:cylindrical}) = CylindricalPoint(pt)
@@ -128,10 +130,12 @@ end
 abstract type Electron end
 abstract type Hole end
 
-function _add_fieldvector_selfrepulsion!(step_vectors::Vector{CartesianVector{T}}, current_pos::Vector{CartesianPoint{T}}, charges::Vector{T}, ϵr::T, ::Type{Electron})::Nothing where {T <: SSDFloat}
+function _add_fieldvector_selfrepulsion!(step_vectors::Vector{CartesianVector{T}}, current_pos::Vector{CartesianPoint{T}}, done::Vector{Bool}, charges::Vector{T}, ϵr::T, ::Type{Electron})::Nothing where {T <: SSDFloat}
     #TO DO: ignore charges that are already collected (not trapped though!)
     for n in eachindex(step_vectors)
+        if done[n] continue end
         for m in eachindex(step_vectors)
+            if done[m] continue end
             if m > n
                 direction::CartesianVector{T} = current_pos[n] .- current_pos[m]
                 tmp::T = elementary_charge * inv(4 * pi * ϵ0 * ϵr * sum(direction.^2))
@@ -144,10 +148,12 @@ function _add_fieldvector_selfrepulsion!(step_vectors::Vector{CartesianVector{T}
 end
 
 
-function _add_fieldvector_selfrepulsion!(step_vectors::Vector{CartesianVector{T}}, current_pos::Vector{CartesianPoint{T}}, charges::Vector{T}, ϵr::T, ::Type{Hole})::Nothing where {T <: SSDFloat}
+function _add_fieldvector_selfrepulsion!(step_vectors::Vector{CartesianVector{T}}, current_pos::Vector{CartesianPoint{T}}, done::Vector{Bool}, charges::Vector{T}, ϵr::T, ::Type{Hole})::Nothing where {T <: SSDFloat}
     #TO DO: ignore charges that are already collected (not trapped though!)
     for n in eachindex(step_vectors)
+        if done[n] continue end
         for m in eachindex(step_vectors)
+            if done[m] continue end
             if m > n
                 direction::CartesianVector{T} = current_pos[n] .- current_pos[m]
                 tmp::T = elementary_charge * inv(4 * pi * ϵ0 * ϵr * sum(direction.^2))
@@ -261,7 +267,9 @@ function _drift_charge!(
                             Δt::T,
                             velocity_field::Interpolations.Extrapolation{<:StaticVector{3}, 3},
                             cdm::AbstractChargeDriftModel{T},
-                            CC::Type;
+                            CC::Type,
+                            diffusion::Bool = false,
+                            self_repulsion::Bool = false;
                             verbose::Bool = true
                         )::Int where {T <: SSDFloat, S}
     
@@ -280,8 +288,8 @@ function _drift_charge!(
         last_real_step_index += 1
         _set_to_zero_vector!(step_vectors)
         _add_fieldvector_drift!(step_vectors, current_pos, drift_path, istep, done, velocity_field, det)
-        _add_fieldvector_diffusion!(step_vectors, current_pos)
-        _add_fieldvector_selfrepulsion!(step_vectors, current_pos, charges, ϵr, CC)
+        if diffusion _add_fieldvector_diffusion!(step_vectors, current_pos) end
+        if self_repulsion _add_fieldvector_selfrepulsion!(step_vectors, current_pos, done, charges, ϵr, CC) end
         _modulate_fieldvector!(step_vectors, current_pos, det.virtual_drift_volumes)    
         _get_step_vectors!(step_vectors, Δt, cdm, CC)
         _check_and_update_position!(step_vectors, current_pos, done, drift_path, timestamps, istep, det, g, point_types, startpos, Δt, verbose)

--- a/src/ChargeDrift/ChargeDrift.jl
+++ b/src/ChargeDrift/ChargeDrift.jl
@@ -117,8 +117,9 @@ function _add_fieldvector_drift!(step_vectors::Vector{CartesianVector{T}}, curre
     nothing
 end
 
-function _add_fieldvector_diffusion!(step_vectors::Vector{CartesianVector{T}}, length::T = T(0.5e3))::Nothing where {T <: SSDFloat}
+function _add_fieldvector_diffusion!(step_vectors::Vector{CartesianVector{T}}, done::Vector{Bool}, length::T = T(0.5e3))::Nothing where {T <: SSDFloat}
     for n in eachindex(step_vectors)
+        if done[n] continue end
         sinθ::T, cosθ::T = sincos(T(rand())*T(2π))
         sinφ::T, cosφ::T = sincos(T(rand())*T(π))
         step_vectors[n] += CartesianVector{T}( length * cosφ * sinθ, length * sinφ * sinθ, length * cosθ )
@@ -291,7 +292,7 @@ function _drift_charge!(
         last_real_step_index += 1
         _set_to_zero_vector!(step_vectors)
         _add_fieldvector_drift!(step_vectors, current_pos, done, velocity_field, det)
-        if diffusion _add_fieldvector_diffusion!(step_vectors) end
+        if diffusion _add_fieldvector_diffusion!(step_vectors, done) end
         if self_repulsion _add_fieldvector_selfrepulsion!(step_vectors, current_pos, done, charges, ϵr, CC) end
         _modulate_fieldvector!(step_vectors, current_pos, det.virtual_drift_volumes)    
         _get_step_vectors!(step_vectors, Δt, cdm, CC)

--- a/src/ChargeDrift/ChargeDrift.jl
+++ b/src/ChargeDrift/ChargeDrift.jl
@@ -35,7 +35,7 @@ end
 
 
 function _drift_charges(detector::SolidStateDetector{T}, grid::Grid{T, 3}, point_types::PointTypes{T, 3},
-                        starting_points::Vector{CartesianPoint{T}},
+                        starting_points::Vector{CartesianPoint{T}}, energies::Vector{T},
                         velocity_field_e::Interpolations.Extrapolation{<:SVector{3}, 3},
                         velocity_field_h::Interpolations.Extrapolation{<:SVector{3}, 3},
                         Δt::RQ; max_nsteps::Int = 2000, verbose::Bool = true)::Vector{EHDriftPath{T}} where {T <: SSDFloat, RQ <: RealQuantity}
@@ -48,8 +48,8 @@ function _drift_charges(detector::SolidStateDetector{T}, grid::Grid{T, 3}, point
     drift_path_h::Array{CartesianPoint{T},2} = Array{CartesianPoint{T},2}(undef, n_events, max_nsteps)
     timestamps_e::Vector{T} = Vector{T}(undef, max_nsteps)
     timestamps_h::Vector{T} = Vector{T}(undef, max_nsteps)
-    n_e::Int = _drift_charge!(drift_path_e, timestamps_e, detector, point_types, grid, starting_points, dt, velocity_field_e, verbose = verbose)
-    n_h::Int = _drift_charge!(drift_path_h, timestamps_h, detector, point_types, grid, starting_points, dt, velocity_field_h, verbose = verbose)
+    n_e::Int = _drift_charge!(drift_path_e, timestamps_e, detector, point_types, grid, starting_points, energies, dt, velocity_field_e, verbose = verbose)
+    n_h::Int = _drift_charge!(drift_path_h, timestamps_h, detector, point_types, grid, starting_points, energies, dt, velocity_field_h, verbose = verbose)
     
     for i in eachindex(starting_points)
         drift_paths[i] = EHDriftPath{T, T}( drift_path_e[i,1:n_e], drift_path_h[i,1:n_h], timestamps_e[1:n_e], timestamps_h[1:n_h] )
@@ -217,6 +217,7 @@ function _drift_charge!(
                             point_types::PointTypes{T, 3, S},
                             g::Grid{T, 3, S},
                             startpos::Vector{CartesianPoint{T}},
+                            energies::Vector{T},
                             Δt::T,
                             velocity_field::Interpolations.Extrapolation{<:StaticVector{3}, 3};
                             verbose::Bool = true

--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -43,7 +43,7 @@ in(evt::Event, simulation::Simulation) = all( pt -> pt in simulation.detector, e
 
 
 function drift_charges!(event::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", verbose::Bool = true)::Nothing where {T <: SSDFloat}
-    event.drift_paths = drift_charges(sim, CartesianPoint.(event.locations), Δt = Δt, max_nsteps = max_nsteps, verbose = verbose)
+    event.drift_paths = drift_charges(sim, CartesianPoint.(event.locations), event.energies, Δt = Δt, max_nsteps = max_nsteps, verbose = verbose)
     nothing
 end
 function get_signal!(event::Event{T}, sim::Simulation{T}, contact_id::Int; Δt::RealQuantity = 5u"ns")::Nothing where {T <: SSDFloat}

--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -42,8 +42,8 @@ in(evt::Event, detector::SolidStateDetector) = all( pt -> pt in detector, evt.lo
 in(evt::Event, simulation::Simulation) = all( pt -> pt in simulation.detector, evt.locations)
 
 
-function drift_charges!(event::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", verbose::Bool = true)::Nothing where {T <: SSDFloat}
-    event.drift_paths = drift_charges(sim, CartesianPoint.(event.locations), event.energies, Δt = Δt, max_nsteps = max_nsteps, verbose = verbose)
+function drift_charges!(event::Event{T}, sim::Simulation{T}; diffusion::Bool = false, self_repulsion::Bool = false, max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", verbose::Bool = true)::Nothing where {T <: SSDFloat}
+    event.drift_paths = drift_charges(sim, CartesianPoint.(event.locations), event.energies, diffusion = diffusion, self_repulsion = self_repulsion, Δt = Δt, max_nsteps = max_nsteps, verbose = verbose)
     nothing
 end
 function get_signal!(event::Event{T}, sim::Simulation{T}, contact_id::Int; Δt::RealQuantity = 5u"ns")::Nothing where {T <: SSDFloat}
@@ -75,8 +75,8 @@ end
     end
 end
 
-function simulate!(event::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", verbose::Bool = true)::Nothing where {T <: SSDFloat}
-    drift_charges!(event, sim, max_nsteps = max_nsteps, Δt = Δt, verbose = verbose)
+function simulate!(event::Event{T}, sim::Simulation{T}; diffusion::Bool = false, self_repulsion::Bool = false, max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", verbose::Bool = true)::Nothing where {T <: SSDFloat}
+    drift_charges!(event, sim, diffusion = diffusion, self_repulsion = self_repulsion, max_nsteps = max_nsteps, Δt = Δt, verbose = verbose)
     get_signals!(event, sim, Δt = Δt)
     nothing
 end

--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -20,6 +20,14 @@ function Event(locations::Vector{<:AbstractCoordinatePoint{T}}, energies::Vector
     return evt
 end
 
+function Event(nbcc::NBodyChargeCloud{T})::Event{T} where {T <: SSDFloat}
+    evt = Event{T}()
+    evt.locations = nbcc.points
+    evt.energies = nbcc.energies
+    evt.waveforms = missing
+    return evt
+end
+
 function Event(evt::NamedTuple{(:evtno, :detno, :thit, :edep, :pos),
          <:Tuple{
             Union{Integer, AbstractVector{<:Integer}},

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -649,10 +649,10 @@ function get_interpolated_drift_field(ef::ElectricField)
 end
 
 function drift_charges( sim::Simulation{T}, starting_positions::Vector{CartesianPoint{T}}, energies::Vector{T};
-                        Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, verbose::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
+                        diffusion::Bool = false, self_repulsion::Bool = false, Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, verbose::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
     return _drift_charges(   sim.detector, sim.point_types.grid, sim.point_types, starting_positions, energies,
                              get_interpolated_drift_field(sim.electric_field), sim.charge_drift_model, 
-                             Δt, max_nsteps = max_nsteps, verbose = verbose)::Vector{EHDriftPath{T}}
+                             Δt, diffusion, self_repulsion, max_nsteps = max_nsteps, verbose = verbose)::Vector{EHDriftPath{T}}
 end
 
 function get_signal(sim::Simulation{T}, drift_paths::Vector{EHDriftPath{T}}, energy_depositions::Vector{T}, contact_id::Int; Δt::TT = T(5) * u"ns") where {T <: SSDFloat, TT}

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -648,9 +648,9 @@ function get_interpolated_drift_field(ef::ElectricField)
     get_interpolated_drift_field(ef.data, ef.grid)
 end
 
-function drift_charges( sim::Simulation{T}, starting_positions::Vector{CartesianPoint{T}};
+function drift_charges( sim::Simulation{T}, starting_positions::Vector{CartesianPoint{T}}, energies::Vector{T};
                         Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, verbose::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
-    return _drift_charges(   sim.detector, sim.point_types.grid, sim.point_types, starting_positions,
+    return _drift_charges(   sim.detector, sim.point_types.grid, sim.point_types, starting_positions, energies,
                              get_interpolated_drift_field(sim.electron_drift_field), get_interpolated_drift_field(sim.hole_drift_field),
                              Δt, max_nsteps = max_nsteps, verbose = verbose)::Vector{EHDriftPath{T}}
 end

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -651,7 +651,7 @@ end
 function drift_charges( sim::Simulation{T}, starting_positions::Vector{CartesianPoint{T}}, energies::Vector{T};
                         Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, verbose::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
     return _drift_charges(   sim.detector, sim.point_types.grid, sim.point_types, starting_positions, energies,
-                             get_interpolated_drift_field(sim.electron_drift_field), get_interpolated_drift_field(sim.hole_drift_field),
+                             get_interpolated_drift_field(sim.electric_field), sim.charge_drift_model, 
                              Δt, max_nsteps = max_nsteps, verbose = verbose)::Vector{EHDriftPath{T}}
 end
 


### PR DESCRIPTION
Steps: 
- [x] Make everything an `Array` and adapt functions accordingly
- [x] Export drift code to smaller functions that are allocation-free
- [x] Remove `electron_drift_field` and `hole_drift_field`
- [x] Pass charges instead of energies to the drift functions
- [x] Implement the framework to simulate diffusion (random-walk) and self-repulsion (N-body repulsion)
- [x] Write tests ?